### PR TITLE
Fixes Sherlock Sept 24 Issue 10 Unused fee logic in flash loan implementation

### DIFF
--- a/src/LoanV2.sol
+++ b/src/LoanV2.sol
@@ -1462,11 +1462,6 @@ contract Loan is ReentrancyGuard, Initializable, UUPSUpgradeable, Ownable2StepUp
             revert UnsupportedToken(token);
         }
         
-        // 0% fee for market diamond, regular fee for others
-        if (msg.sender == getMarketDiamond()) {
-            return 0;
-        }
-        
         return (amount * getFlashLoanFee()) / 10000; // Fee is in basis points
     }
 


### PR DESCRIPTION
Fixes issue 10 https://github.com/sherlock-audit/2025-09-40acres-finance-sept-24th/issues/10
- removes unused fee logic assumes fee set to 0 until such time flash loans are public and this logic may be needed