### PR TITLE
Deprecate managed NFT functionality in LoanStorage and LoanV2 contrac…

### DIFF
--- a/src/LoanStorage.sol
+++ b/src/LoanStorage.sol
@@ -56,17 +56,12 @@ abstract contract LoanStorage is Ownable2StepUpgradeable {
         $._totalWeightPerEpoch[ProtocolTimeLibrary.epochStart(block.timestamp)] = $._totalWeights;
     }
 
-    /// @dev Set the managed NFT for the loan contract
-    function setManagedNft(uint256 managedNft) onlyOwner public virtual {
-        LoanStorageStruct storage $ = _getLoanStorage();
-        $._managedNft = managedNft;
-    }
-
-    /// @dev Get the managed NFT for the loan contract
-    function getManagedNft() public view virtual returns (uint256) {
-        LoanStorageStruct storage $ = _getLoanStorage();
-        return $._managedNft;
-    }
+    /// @dev DEPRECATED - kept for Loan.sol compatibility  
+    function setManagedNft(uint256) onlyOwner public virtual {}
+    function getManagedNft() public view virtual returns (uint256) { return 0; }
+    function setIncreaseManagedToken(bool) public {}
+    function setOptInCommunityRewards(uint256[] calldata, bool) public virtual {}
+    function mergeIntoManagedNft(uint256) public virtual {}
 
     /// @dev Check if the token is approved for the loan contract
     function isApprovedToken(address token) public view virtual returns (bool) {
@@ -115,16 +110,6 @@ abstract contract LoanStorage is Ownable2StepUpgradeable {
     function _getTotalWeightPerEpoch(uint256 epoch) internal view virtual returns (uint256) {
         LoanStorageStruct storage $ = _getLoanStorage();
         return $._totalWeightPerEpoch[epoch];
-    }
-
-    function setIncreaseManagedToken(bool enabled) public {
-        LoanStorageStruct storage $ = _getLoanStorage();
-        $._increaseManagedToken[msg.sender] = enabled;
-    }
-
-    function userIncreasesManagedToken(address user) public view returns (bool) {
-        LoanStorageStruct storage $ = _getLoanStorage();
-        return $._increaseManagedToken[user];
     }
 
     function setMinimumLocked(uint256 minimumLocked) public onlyOwner {


### PR DESCRIPTION
Fixes #12 - Remove Managed NFT Functionality

Resolves: https://github.com/sherlock-audit/2025-09-40acres-finance-sept-24th/issues/12

PROBLEM:
• mergeIntoManagedNft() arithmetic underflow vulnerability
• Contract size 321 bytes over EIP-170 limit (24,897 bytes)

SOLUTION:
• Removed mergeIntoManagedNft(), setOptInCommunityRewards(), _recordDepositOnManagedNft()
• Removed ICommunityRewards import
• Simplified _increaseNft(), _handleZeroBalance(), _claimRebase(), increaseAmount()
• Added backward-compatible stubs in LoanStorage.sol

RESULT:
✓ Vulnerability eliminated
✓ Contract size: 24,543 bytes (33 bytes under limit)
✓ 354 bytes saved