### PR TITLE
Fix Sherlock Sept24 Issue 15 - Improper fee handling in loan payoff leading to fee loss

### DIFF
--- a/src/LoanV2.sol
+++ b/src/LoanV2.sol
@@ -402,8 +402,9 @@ contract Loan is ReentrancyGuard, Initializable, UUPSUpgradeable, Ownable2StepUp
         // take out unpaid fees first
         if(loan.unpaidFees > 0) {
             uint256 feesPaid = loan.unpaidFees;
-            // Apply 25% cap only if payment won't fully settle the loan
-            if(amount - feesPaid < loan.balance) {
+            // For partial payments, cap fees at 25% to protect borrower
+            // For full settlement, collect all fees to ensure protocol is paid
+            if(amount < loan.balance) {
                 uint256 maxFees = (amount * 25) / 100;
                 if(feesPaid > maxFees) {
                     feesPaid = maxFees;


### PR DESCRIPTION
- Fixes https://github.com/sherlock-audit/2025-09-40acres-finance-sept-24th/issues/15
- Apply 25% cap only if payment won't fully settle the loan