### PR TITLE
Sherlock sept24 issue 16

### DIFF
--- a/src/LoanUtils.sol
+++ b/src/LoanUtils.sol
@@ -15,7 +15,6 @@ library LoanUtils {
         // Calculate the maximum loan ignoring vault supply constraints
         uint256 maxLoanIgnoreSupply = (((veBalance * rewardsRate) / 1000000) *
             multiplier) / 1e12; // rewardsRate * veNFT balance of token
-        uint256 maxLoan = (maxLoanIgnoreSupply * 10000) / (10000 + 80);
 
         // Calculate the maximum utilization ratio (80% of the vault supply)
         uint256 vaultSupply = vaultBalance + outstandingCapital;
@@ -26,13 +25,17 @@ library LoanUtils {
             return (0, maxLoanIgnoreSupply);
         }
 
-        // If the current loan balance exceeds the maximum loan, no additional loans can be made
-        if (currentLoanBalance >= maxLoan) {
+        // If the current loan balance exceeds the maximum capacity, no additional loans can be made
+        if (currentLoanBalance >= maxLoanIgnoreSupply) {
             return (0, maxLoanIgnoreSupply);
         }
 
-        // Subtract the current loan balance from the maximum loan
-        maxLoan = maxLoan - currentLoanBalance;
+        // Calculate remaining headroom under LTV
+        uint256 headroom = maxLoanIgnoreSupply - currentLoanBalance;
+
+        // Fee-adjust the headroom to get actual borrowable amount
+        // When user borrows X, balance increases by X + 0.8% fee
+        uint256 maxLoan = (headroom * 10000) / (10000 + 80);
 
         // Ensure the loan amount does not exceed the available vault supply
         uint256 vaultAvailableSupply = maxUtilization - outstandingCapital;
@@ -57,7 +60,6 @@ library LoanUtils {
     ) public pure returns (uint256, uint256) {
         // Calculate the maximum loan ignoring vault supply constraints
         uint256 maxLoanIgnoreSupply = (veBalance * ltv) / 10000; // ltv * veNFT balance of token
-        uint256 maxLoan = (maxLoanIgnoreSupply * 10000) / (10000 + 80);
 
         // Calculate the maximum utilization ratio (80% of the vault supply)
         uint256 vaultSupply = vaultBalance + outstandingCapital;
@@ -68,13 +70,17 @@ library LoanUtils {
             return (0, maxLoanIgnoreSupply);
         }
 
-        // If the current loan balance exceeds the maximum loan, no additional loans can be made
-        if (currentLoanBalance >= maxLoan) {
+        // If the current loan balance exceeds the maximum capacity, no additional loans can be made
+        if (currentLoanBalance >= maxLoanIgnoreSupply) {
             return (0, maxLoanIgnoreSupply);
         }
 
-        // Subtract the current loan balance from the maximum loan
-        maxLoan = maxLoan - currentLoanBalance;
+        // Calculate remaining headroom under LTV
+        uint256 headroom = maxLoanIgnoreSupply - currentLoanBalance;
+
+        // Fee-adjust the headroom to get actual borrowable amount
+        // When user borrows X, balance increases by X + 0.8% fee
+        uint256 maxLoan = (headroom * 10000) / (10000 + 80);
 
         // Ensure the loan amount does not exceed the available vault supply
         uint256 vaultAvailableSupply = maxUtilization - outstandingCapital;

--- a/src/LoanV2.sol
+++ b/src/LoanV2.sol
@@ -1225,7 +1225,7 @@ contract Loan is ReentrancyGuard, Initializable, UUPSUpgradeable, Ownable2StepUp
     ) internal view virtual returns (uint256) {
         IVotingEscrow.LockedBalance memory lockedBalance = _ve.locked(tokenId);
         if (
-            !lockedBalance.isPermanent && lockedBalance.end < ProtocolTimeLibrary.epochStart(block.timestamp)
+            !lockedBalance.isPermanent && lockedBalance.end <= block.timestamp
         ) {
             return 0;
         }

--- a/src/Pharaoh/PharaohLoanV2.sol
+++ b/src/Pharaoh/PharaohLoanV2.sol
@@ -91,7 +91,7 @@ contract PharaohLoanV2 is Loan {
 
     function _getLockedAmount(uint256 tokenId) internal view override returns (uint256) {
         IVotingEscrow.LockedBalance memory lockedBalance = IVotingEscrow(address(_ve)).locked(tokenId);
-        if (lockedBalance.end < ProtocolTimeLibrary.epochStart(block.timestamp)) {
+        if (lockedBalance.end <= block.timestamp) {
             return 0;
         }
         require(lockedBalance.amount >= 0);


### PR DESCRIPTION
- fixes https://github.com/sherlock-audit/2025-09-40acres-finance-sept-24th/issues/16
- Expired veNFTs now zero-out at expiry (block.timestamp)
- max borrow uses fee‑adjusted headroom (maxCapacity - loan.balance)