### PR TITLE
feat(contracts): add walletFacetAbi to @40-acres/contracts

### DIFF
--- a/.changeset/wallet-facet.md
+++ b/.changeset/wallet-facet.md
@@ -1,0 +1,11 @@
+---
+"@40-acres/contracts": minor
+---
+
+Add `walletFacetAbi` (per-user account utilities: `receiveERC20`,
+`transferERC20`, `transferNFT`, `withdrawERC20`, `swap`,
+`enforceCollateralRequirements`, `onERC721Received`).
+
+Frontend can now consume this ABI directly via
+`import { walletFacetAbi } from '@40-acres/contracts'` instead of the
+hand-typed `WALLET_FACET_ABI` in `src/abi/wallet_facet_abi.ts`.

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -43,6 +43,11 @@ export default defineConfig({
         // Note: VexyMarketplace is third-party (not in our src/). The frontend
         // ships its own copy of that ABI; it does not belong here.
 
+        // Wallet facet (per-user account utilities: receiveERC20,
+        // transferERC20, transferNFT, withdrawERC20, swap).
+        // Frontend consumes this via portfolio-operations/operations/wallet.ts.
+        'WalletFacet.sol/WalletFacet.json',
+
         // Pharaoh adapter (Avalanche). PharaohVault is just `contract Vault
         // is VaultV2` -- a thin wrapper, so we don't ship it (VaultV2 above
         // is the parent). PharaohLoan (V1) is dropped per the V1-erasure plan.


### PR DESCRIPTION
## Summary

Adds \`WalletFacet.sol\`'s ABI to the \`@40-acres/contracts\` package so the frontend can stop hand-maintaining \`src/abi/wallet_facet_abi.ts\`.

Two-line change to \`wagmi.config.ts\` + a Changesets entry. Once this merges + the auto-version-PR merges, \`@40-acres/contracts@0.2.0\` ships and the frontend can consume \`walletFacetAbi\` directly.

## What gets exported

\`walletFacetAbi\` covering 7 functions on \`WalletFacet\`:

| Function | Signature |
|---|---|
| \`receiveERC20\` | \`(address token, uint256 amount)\` |
| \`transferERC20\` | \`(address token, uint256 amount, address to)\` |
| \`transferNFT\` | \`(address nft, uint256 tokenId, address to)\` |
| \`withdrawERC20\` | \`(address token, uint256 amount)\` |
| \`swap\` | \`(SwapMod.RouteParams) → uint256\` |
| \`enforceCollateralRequirements\` | \`() → bool\` |
| \`onERC721Received\` | (ERC721 hook) |

The frontend's hand-typed \`WALLET_FACET_ABI\` covers only 3 of these (receiveERC20, transferERC20, transferNFT). Package version is a strict superset.

## Verified locally

\`\`\`bash
forge build
pnpm wagmi generate
grep "walletFacetAbi" packages/contracts/src/generated.ts
# → export const walletFacetAbi = [...]
\`\`\`

## After merge

1. CI's release workflow opens a "Version Packages" PR bumping to \`0.2.0\`
2. Merge that → \`@40-acres/contracts@0.2.0\` publishes
3. Frontend can then consume \`walletFacetAbi\` (separate frontend PR)

## Test plan

- [ ] CI green
- [ ] After merge: Version Packages PR opens with \`0.2.0\`
- [ ] After version PR merges: \`@40-acres/contracts@0.2.0\` visible at https://github.com/orgs/40-Acres/packages/npm/contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)