### PR TITLE
feat(contracts): add 9 facet ABIs (diamond + xPharaoh) to package

### DIFF
--- a/.changeset/facets-and-xpharaoh.md
+++ b/.changeset/facets-and-xpharaoh.md
@@ -1,0 +1,20 @@
+---
+"@40-acres/contracts": minor
+---
+
+Add 9 facet ABIs to the package:
+
+- `collateralFacetAbi`, `erc4626CollateralFacetAbi` — collateral management
+  (addCollateral, removeCollateral, getLockedCollateral, etc.)
+- `erc4626LendingFacetAbi` — borrow, getTotalDebt
+- `rewardsProcessingFacetAbi` — pay
+- `yieldBasisLpFacetAbi` — deposit, withdraw
+- `veYieldBasisFacetAbi` — createLock, increaseLock
+- `dynamicVotingEscrowFacetAbi` — merge, mergeInternal
+- `votingFacetAbi` — batchVote, setVotingMode
+- `xPharaohFacetAbi` — Pharaoh's V1 facet (xPhar* methods),
+  still actively used in production despite living under `src/legacy/`.
+
+Replaces the frontend's hand-typed `FACETS_ABI` (a synthetic union over
+the diamond proxy) with individual facet ABIs that consumers pick per
+call site. Also unblocks the migration of `phar_abi.ts` to the package.

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -48,6 +48,24 @@ export default defineConfig({
         // Frontend consumes this via portfolio-operations/operations/wallet.ts.
         'WalletFacet.sol/WalletFacet.json',
 
+        // Diamond facets exposed via the portfolio account proxy.
+        // Frontend currently has these methods union-typed in src/abi/facets_abi.ts;
+        // shipping the individual facet ABIs lets consumers pick per call site
+        // (e.g. lendingFacetAbi for borrow(), votingFacetAbi for batchVote()).
+        'ERC4626LendingFacet.sol/ERC4626LendingFacet.json',
+        'RewardsProcessingFacet.sol/RewardsProcessingFacet.json',
+        'YieldBasisLpFacet.sol/YieldBasisLpFacet.json',
+        'CollateralFacet.sol/CollateralFacet.json',
+        'ERC4626CollateralFacet.sol/ERC4626CollateralFacet.json',
+        'DynamicVotingEscrowFacet.sol/DynamicVotingEscrowFacet.json',
+        'veYieldBasisFacet.sol/veYieldBasisFacet.json',
+        'VotingFacet.sol/VotingFacet.json',
+
+        // XPharaohFacet -- Pharaoh's V1 facet, still active in production
+        // (Pharaoh's V1 is NOT being erased like other platforms). Lives in
+        // src/legacy/ for historical organization but functionally current.
+        'XPharaohFacet.sol/XPharaohFacet.json',
+
         // Pharaoh adapter (Avalanche). PharaohVault is just `contract Vault
         // is VaultV2` -- a thin wrapper, so we don't ship it (VaultV2 above
         // is the parent). PharaohLoan (V1) is dropped per the V1-erasure plan.


### PR DESCRIPTION
## Summary

Adds the lending/collateral/voting/rewards facets that compose the diamond proxy, plus Pharaoh's V1 \`XPharaohFacet\` (still active in production despite living under \`src/legacy/\`).

This unblocks the final 3 frontend migrations:
1. \`facets_abi.ts\` (synthetic union over diamond) → individual facet ABIs per call site
2. \`phar_abi.ts\` (PHAR_USER_ACCOUNT_ABI) → \`xPharaohFacetAbi\`
3. (Q1's \`x33_abi\` migration uses an existing export, no package change needed)

## Added (9 contracts → 25 total exports)

| Facet | Methods (frontend uses) |
|---|---|
| \`CollateralFacet\`, \`ERC4626CollateralFacet\` | \`addCollateral\`, \`removeCollateral\`, \`removeCollateralTo\`, \`getLockedCollateral\`, \`getOriginTimestamp\` |
| \`ERC4626LendingFacet\` | \`borrow\`, \`getTotalDebt\` |
| \`RewardsProcessingFacet\` | \`pay\` |
| \`YieldBasisLpFacet\` | \`deposit\`, \`withdraw\` |
| \`veYieldBasisFacet\` | \`createLock\`, \`increaseLock\` |
| \`DynamicVotingEscrowFacet\` | \`merge\`, \`mergeInternal\` |
| \`VotingFacet\` | \`batchVote\`, \`setVotingMode\` |
| \`XPharaohFacet\` (legacy/) | \`xPharRequestLoan\`, \`xPharClaim\`, \`xPharVote\`, etc. (still production) |

Note: frontend's \`FACETS_ABI\` had \`isEligibleForManualVoting\` which doesn't exist anywhere in current src/ — dead reference, will be dropped during the frontend migration (caught by tsc).

## Verified locally

\`\`\`bash
forge build
pnpm wagmi generate
grep -c "^export const" packages/contracts/src/generated.ts
# → 25  (was 16; added 9)
\`\`\`

## After merge

Standard Changesets flow: this triggers a Version Packages PR bumping \`0.2.0 → 0.3.0\`. Merge that → \`@40-acres/contracts@0.3.0\` publishes. Then the frontend can consume the new ABIs in 3 stacked migration PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)