### PR TITLE
ci(release): dispatch contracts-released event to consumers after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,42 @@ jobs:
           # token from ~/.npmrc (set up by actions/setup-node above).
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Notify downstream consumers (frontend, later homestead) that a
+      # new @40-acres/contracts version was published, so they can
+      # auto-open a bump PR. This sidesteps Dependabot's daily-at-best
+      # cadence and gets a PR open within ~3 minutes of publish.
+      #
+      # Failures here do NOT fail the release -- Dependabot is the
+      # weekly safety net.
+      - name: Notify consumers of release
+        if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
+        env:
+          DISPATCH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${DISPATCH_TOKEN:-}" ]]; then
+            echo "::warning::RELEASE_DISPATCH_TOKEN not set -- skipping consumer notification."
+            exit 0
+          fi
+          version=$(echo "$PUBLISHED_PACKAGES" \
+            | jq -r '.[] | select(.name == "@40-acres/contracts") | .version')
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "::notice::No @40-acres/contracts in publishedPackages -- nothing to dispatch."
+            exit 0
+          fi
+          echo "Dispatching contracts-released event to consumers (version=$version)..."
+          for consumer in frontend; do
+            echo "-> 40-Acres/$consumer"
+            curl --fail-with-body -sS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "Authorization: Bearer $DISPATCH_TOKEN" \
+              "https://api.github.com/repos/40-Acres/$consumer/dispatches" \
+              -d "$(jq -nc --arg v "$version" '{event_type: "contracts-released", client_payload: {version: $v}}')"
+          done
+
       - name: Summary
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- After a successful Changesets publish, POST a \`repository_dispatch\` (\`contracts-released\`) to every consumer repo (currently \`frontend\`; \`homestead\` joins in Phase 4).
- The consumer's listener workflow opens a bump PR within ~3 minutes of publish — versus Dependabot's daily-at-best cadence.
- Failures here do **not** fail the release (\`continue-on-error: true\`). Dependabot remains the weekly safety net.

## Why a separate token
\`secrets.GITHUB_TOKEN\` is scoped to this repo only — it cannot fire \`repository_dispatch\` to a sibling repo. Hence \`RELEASE_DISPATCH_TOKEN\`, a fine-grained PAT scoped to \`40-Acres/frontend\` (and homestead later) with \`Actions: write\`.

## Companion PR
Frontend adds the listener workflow in a parallel PR. Either merge order is safe.

## Test plan
- [x] YAML parses (validated locally).
- [ ] After merging, the next real publish (or a published Version Packages PR) fires the dispatch — confirm the frontend listener kicks off a workflow.
- [ ] The frontend "Auto-bump @40-acres/contracts" workflow opens a PR titled \`chore(deps): bump @40-acres/contracts to <version>\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)