### PR TITLE
feat(contracts): ship raw .abi.json + dispatch homestead (Phase 4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
             exit 0
           fi
           echo "Dispatching contracts-released event to consumers (version=$version)..."
-          for consumer in frontend; do
+          for consumer in frontend homestead; do
             echo "-> 40-Acres/$consumer"
             curl --fail-with-body -sS -X POST \
               -H "Accept: application/vnd.github+json" \

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ node_modules/
 packages/contracts/dist/
 packages/contracts/src/generated.ts
 packages/contracts/src/addresses.ts
+packages/contracts/abis/
 packages/contracts/*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "description": "Workspace root for the loan-contracts repo. The publishable package lives at packages/contracts.",
   "scripts": {
     "build:abis": "wagmi generate",
+    "build:abi-json": "tsx packages/contracts/scripts/build-abis.ts",
     "build:addresses": "tsx packages/contracts/scripts/build-addresses.ts",
-    "build:package": "pnpm build:abis && pnpm build:addresses && pnpm --filter @40-acres/contracts build",
+    "build:package": "pnpm build:abis && pnpm build:abi-json && pnpm build:addresses && pnpm --filter @40-acres/contracts build",
     "validate:addresses": "bash addresses/validate.sh",
     "changeset": "changeset",
     "changeset:from-diff": "tsx scripts/changeset-from-diff.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,6 +15,7 @@
   "files": [
     "dist",
     "src",
+    "abis",
     "README.md"
   ],
   "publishConfig": {
@@ -23,7 +24,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "clean": "rm -rf dist src/generated.ts src/addresses.ts"
+    "clean": "rm -rf dist src/generated.ts src/addresses.ts abis"
   },
   "peerDependencies": {
     "abitype": "^1.0.0"

--- a/packages/contracts/scripts/build-abis.ts
+++ b/packages/contracts/scripts/build-abis.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env tsx
+/**
+ * Reads Foundry build artifacts under `out/<source>.sol/<contract>.json` and
+ * emits raw `.abi.json` files to `packages/contracts/abis/<contract>.abi.json`.
+ *
+ * Why ship raw JSON when wagmi-cli already produces TS exports?
+ *   Go consumers (homestead) need plain `.abi` JSON to feed into `abigen`.
+ *   The TS `as const` shape is unusable from Go. Bundling raw JSON in the
+ *   same npm package keeps frontend (TS) and homestead (Go) versioned
+ *   together with no second publish artifact to manage.
+ *
+ * Curated list mirrors `wagmi.config.ts` -- when adding a contract there,
+ * add it here too. The lists are intentionally NOT deduplicated to keep
+ * each file self-contained and readable.
+ *
+ * Run from the workspace root:  pnpm build:abi-json
+ */
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, '..', '..', '..');
+const foundryOut = join(repoRoot, 'out');
+const abisDir = join(repoRoot, 'packages', 'contracts', 'abis');
+
+// Keep in sync with `wagmi.config.ts`. Each entry is the artifact path under
+// `out/`, formatted as `<source>.sol/<Contract>.json`.
+const ARTIFACTS = [
+  // Core contracts
+  'LoanV2.sol/Loan.json',
+  'VaultV2.sol/Vault.json',
+  'EntryPoint.sol/EntryPoint.json',
+  'Swapper.sol/Swapper.json',
+
+  // V2 portfolio account architecture
+  'PortfolioManager.sol/PortfolioManager.json',
+  'PortfolioFactory.sol/PortfolioFactory.json',
+  'FacetRegistry.sol/FacetRegistry.json',
+
+  // Marketplaces
+  'PortfolioMarketplace.sol/PortfolioMarketplace.json',
+  'FortyAcresMarketplaceFacet.sol/FortyAcresMarketplaceFacet.json',
+  'VexyFacet.sol/VexyFacet.json',
+
+  // Wallet facet
+  'WalletFacet.sol/WalletFacet.json',
+
+  // Diamond facets
+  'ERC4626LendingFacet.sol/ERC4626LendingFacet.json',
+  'RewardsProcessingFacet.sol/RewardsProcessingFacet.json',
+  'YieldBasisLpFacet.sol/YieldBasisLpFacet.json',
+  'CollateralFacet.sol/CollateralFacet.json',
+  'ERC4626CollateralFacet.sol/ERC4626CollateralFacet.json',
+  'DynamicVotingEscrowFacet.sol/DynamicVotingEscrowFacet.json',
+  'veYieldBasisFacet.sol/veYieldBasisFacet.json',
+  'VotingFacet.sol/VotingFacet.json',
+
+  // XPharaohFacet (V1, still in production)
+  'XPharaohFacet.sol/XPharaohFacet.json',
+
+  // Pharaoh adapter
+  'XPharaohLoan.sol/XPharaohLoan.json',
+  'PharaohLoanV2.sol/PharaohLoanV2.json',
+  'PharaohLoanV2Native.sol/PharaohLoanV2Native.json',
+  'PharaohSwapper.sol/PharaohSwapper.json',
+
+  // Etherex adapter
+  'EtherexLoan.sol/EtherexLoan.json',
+
+  // Blackhole adapter (V1)
+  'BlackholeLoan.sol/BlackholeLoan.json',
+];
+
+function build() {
+  // Wipe and recreate so removed artifacts don't linger as stale files.
+  if (existsSync(abisDir)) rmSync(abisDir, { recursive: true });
+  mkdirSync(abisDir, { recursive: true });
+
+  let written = 0;
+  const missing: string[] = [];
+  for (const artifact of ARTIFACTS) {
+    const artifactPath = join(foundryOut, artifact);
+    if (!existsSync(artifactPath)) {
+      missing.push(artifact);
+      continue;
+    }
+
+    const json = JSON.parse(readFileSync(artifactPath, 'utf8'));
+    if (!Array.isArray(json.abi)) {
+      console.error(`Artifact ${artifact} has no .abi field or it's not an array`);
+      process.exit(1);
+    }
+
+    // Contract name is the filename minus .json -- matches Foundry's
+    // contract name and homestead's existing naming convention
+    // (e.g. PortfolioManager.abi).
+    const contract = artifact.split('/').pop()!.replace(/\.json$/, '');
+    const outPath = join(abisDir, `${contract}.abi.json`);
+    writeFileSync(outPath, JSON.stringify(json.abi, null, 2) + '\n');
+    written++;
+  }
+
+  if (missing.length > 0) {
+    console.error('Missing Foundry artifacts (run `forge build` first):');
+    for (const m of missing) console.error(`  - ${m}`);
+    process.exit(1);
+  }
+
+  console.log(`Wrote ${written} ABI file(s) to ${abisDir}`);
+}
+
+build();


### PR DESCRIPTION
## Summary
Phase 4 of the \`@40-acres/contracts\` migration. Two pieces:

### 1. Ship raw \`.abi.json\` for Go consumers
- New build step \`pnpm build:abi-json\` extracts raw ABI JSON from Foundry artifacts into \`packages/contracts/abis/<Contract>.abi.json\`.
- Wired into \`pnpm build:package\`, gitignored locally, included in the npm tarball via the \`files\` field.
- TS exports unchanged — frontend ignores \`abis/\`. Homestead's \`abigen\` pipeline consumes it.
- Curated artifact list mirrors \`wagmi.config.ts\` (with a comment noting they should stay in sync).

### 2. Dispatch \`contracts-released\` to homestead too
- \`release.yml\`'s consumer loop changes from \`for consumer in frontend\` to \`for consumer in frontend homestead\`.
- One-word change. Companion listener PR in homestead picks up the dispatch.

## Companion PR
[40-Acres/homestead#120](https://github.com/40-Acres/homestead/pull/120) — listener workflow, \`.npmrc\` for GH Packages auth, copies \`abis/*.abi.json\` into \`src/core/contracts/\`, regenerates Go bindings via \`make generate-contracts\`, opens auto PR.

## Pre-merge requirements
- [x] \`RELEASE_DISPATCH_TOKEN\` PAT scope already updated to include \`40-Acres/homestead\` (confirmed).
- [x] All 26 source files in the curated artifact list verified to exist in \`src/\`.

## Merge order
Either order is safe:
- If this merges first → next publish ships \`abis/\` but homestead listener doesn't exist yet (dispatch fires into the void, no harm).
- If homestead#120 merges first → listener exists but \`abis/\` not yet shipped (workflow_dispatch test would error with a clear message; real publish doesn't fire dispatch yet).

Recommended: merge homestead#120 first, then this. Then trigger a small no-op publish (like #211 was) to validate end-to-end.

## Test plan
- [ ] Merge this PR. Wait for the auto-opened "Version Packages" PR.
- [ ] Merge that. \`release.yml\` runs, builds the package (now including the \`abis/\` folder), publishes, fires dispatch to both frontend and homestead.
- [ ] Verify within ~5 min:
  - Frontend: \`chore(deps): bump @40-acres/contracts to <new>\` PR opens (existing flow).
  - Homestead: \`chore(contracts): sync ABIs and Go bindings to @40-acres/contracts@<new>\` PR opens (new flow).
- [ ] Merge both auto-PRs once CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)