### PR TITLE
chore(changeset): add minor bump for abis/ folder (catches up #213)

### DIFF
--- a/.changeset/abi-json-export.md
+++ b/.changeset/abi-json-export.md
@@ -1,0 +1,5 @@
+---
+"@40-acres/contracts": minor
+---
+
+Ship raw `.abi.json` files alongside the TypeScript exports. The new `abis/` folder in the published tarball contains plain ABI JSON for each of the 26 curated contracts (`Loan.abi.json`, `PortfolioManager.abi.json`, etc.), enabling Go consumers (homestead) to feed them directly into `abigen`. TS consumers (frontend) ignore `abis/` and continue importing the typed exports unchanged.


### PR DESCRIPTION
## Summary
PR [#213](https://github.com/40-Acres/loan-contracts/pull/213) added the \`abis/\` folder to the published package (raw \`.abi.json\` for Go consumers) but I forgot the changeset. The pre-commit hook only enforces it for \`addresses/**/*.json\` changes, so the silent miss landed.

\`release.yml\` ran on the merge, found no changesets, and skipped publish — homestead's listener never fires until a new version actually publishes. This catches it up.

## Effect of merging
Next \`release.yml\` run opens a **"Version Packages"** PR with a minor bump describing the \`abis/\` export. Merge that to publish \`@40-acres/contracts@0.4.0\` and trigger the auto-bump PRs in both frontend and homestead.

## Lesson learned
This is exactly the silent-miss failure mode CLAUDE.md describes. We could close the gap by extending \`.githooks/pre-commit\` to also enforce changesets on \`packages/contracts/**\`, \`src/**/*.sol\`, and \`wagmi.config.ts\` changes — but that's a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)