### PR TITLE
chore: changeset for Hydrex marketplace buyer code (#232)

### DIFF
--- a/.changeset/hydrex-marketplace-buy-from.md
+++ b/.changeset/hydrex-marketplace-buy-from.md
@@ -1,0 +1,5 @@
+---
+"@40-acres/contracts": minor
+---
+
+Ship the Hydrex marketplace buyer code that 1.1.0's changelog described ahead of the merge (landed in #232). `FortyAcresMarketplaceFacet.buyFortyAcresListingFrom(tokenId, nonce, marketplace)` — allowlist-gated via `PortfolioFactoryConfig.setAllowedMarketplace` / `isAllowedMarketplace` — lets the shared Base portfolio diamond purchase from non-aerodrome marketplaces (required for portfolio-mode buys of veHydrex listings on the central PortfolioMarketplace `0xd6AAa9…70Bc`). The original `buyFortyAcresListing(tokenId, nonce)` is unchanged. Regenerates the package ABI so `fortyAcresMarketplaceFacetAbi` exposes `buyFortyAcresListingFrom`, which downstream consumers (frontend portfolio-buy flow) need.


### PR DESCRIPTION
## Why

#232 merged the Hydrex marketplace **buyer** code — `FortyAcresMarketplaceFacet.buyFortyAcresListingFrom(tokenId, nonce, marketplace)` + the `PortfolioFactoryConfig` allowlist — that 1.1.0's changelog had described *ahead of* the actual merge. But #232 landed **without a changeset**, so the release pipeline didn't bump or publish. The published `@40-acres/contracts@1.1.0` therefore still lacks `buyFortyAcresListingFrom` in its ABI, and downstream consumers (the frontend portfolio-buy flow for veHydrex) can't reach it.

## What

Adds a `minor` changeset for `@40-acres/contracts` so merging this opens the "Version Packages" PR → publishes (≈1.2.0) with the regenerated ABI exposing `buyFortyAcresListingFrom`.

## After merge
1. Merge the auto **"Version Packages"** PR → publishes the new version.
2. Frontend bumps `@40-acres/contracts` to it and wires the portfolio-buy op via the package ABI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)